### PR TITLE
Fix Rocketchat notification payload and link formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'java'
-sourceCompatibility = 1.6
-project.version = 0.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+project.version = 0.7
 defaultTasks 'clean', 'build'
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
     pluginLibs
 
-    //declare compile to extend from pluginLibs so it inherits the dependencies
-    compile{
+    implementation {
         extendsFrom pluginLibs
     }
 }
@@ -20,7 +20,9 @@ repositories {
 dependencies {
     pluginLibs group: 'org.freemarker', name: 'freemarker', version: '2.3.20'
     pluginLibs group: 'org.json', name: 'json', version: '20180130'
-    compile(group:'org.rundeck', name: 'rundeck-core', version: '2.1.1')
+    implementation(group: 'org.freemarker', name: 'freemarker', version: '2.3.20')
+    implementation(group: 'org.json', name: 'json', version: '20180130')
+    implementation(group:'org.rundeck', name: 'rundeck-core', version: '2.1.1')
 }
 
 // task to copy plugin libs to output/lib dir
@@ -42,7 +44,3 @@ jar {
 
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '1.10'
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/src/main/java/com/jszaszvari/rundeck/plugins/rocketchat/RocketChatNotificationPlugin.java
+++ b/src/main/java/com/jszaszvari/rundeck/plugins/rocketchat/RocketChatNotificationPlugin.java
@@ -43,6 +43,9 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.*;
 
+import java.nio.charset.StandardCharsets;
+import java.io.OutputStream;
+
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.cache.FileTemplateLoader;
 import freemarker.cache.MultiTemplateLoader;
@@ -184,7 +187,7 @@ public class RocketChatNotificationPlugin implements NotificationPlugin {
 
         HttpURLConnection connection = null;
         InputStream responseStream = null;
-        String body = "payload=" + URLEncoder.encode(message);
+        String body = message;
         try {
             connection = openConnection(requestUrl);
             putRequestStream(connection, body);
@@ -218,15 +221,13 @@ public class RocketChatNotificationPlugin implements NotificationPlugin {
     private void putRequestStream(HttpURLConnection connection, String message) {
         try {
             connection.setRequestMethod("POST");
-//            connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("charset", "utf-8");
+            connection.setRequestProperty("Content-Type", "application/json");
 
             connection.setDoInput(true);
             connection.setDoOutput(true);
-            DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-            wr.writeBytes(message);
-            wr.flush();
-            wr.close();
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(message.getBytes(StandardCharsets.UTF_8));
+            }
         } catch (IOException ioEx) {
             throw new RocketChatNotificationPluginException("Error putting data to Rocket.Chat: [" + ioEx.getMessage() + "].", ioEx);
         }

--- a/src/main/resources/templates/rocket-chat-incoming-message.ftl
+++ b/src/main/resources/templates/rocket-chat-incoming-message.ftl
@@ -15,7 +15,7 @@
 {
    "channel":"${channel}",
    "attachments":[
-      {  
+      {
 	 "title":"RunDeck Job ${state}",
          "channel":"${channel}",
          "icon_emoji":":rundeck:",
@@ -24,7 +24,7 @@
          "fields":[
             {
                "title":"Job Name",
-               "value":"<${executionData.job.href}|${jobName}>",
+               "value":"[${jobName}](${executionData.job.href})",
                "short":true
             },
             {
@@ -39,7 +39,7 @@
             },
             {
                "title":"Execution ID",
-               "value":"<${executionData.href}|#${executionData.id}>",
+               "value":"[#${executionData.id}](${executionData.href})",
                "short":true
             },
             {


### PR DESCRIPTION
Port of https://github.com/JSzaszvari/rundeck-rocketchat-notifier/pull/14 which fixes the rocketchat payload to send application/json rather than urlencoded.

Also includes the original changes in v0.1.2 of our fork (54285d8dd3b466d5d949bd6d9244dda08aa8ec8e)

Ref https://phabricator.tools.flnltd.com/D219310